### PR TITLE
Add DNS whitelist option to CA generation

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -280,6 +280,8 @@ func (m *mkcert) makeCertFromCSR() {
 func (m *mkcert) loadCA() {
 	if !pathExists(filepath.Join(m.CAROOT, rootName)) {
 		m.newCA()
+	} else if len(m.dnsWhitelist) > 0 {
+		log.Println("WARN: CA already exists, -permit flag is being ignored")
 	}
 
 	certPEMBlock, err := ioutil.ReadFile(filepath.Join(m.CAROOT, rootName))
@@ -343,6 +345,8 @@ func (m *mkcert) newCA() {
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 		MaxPathLenZero:        true,
+
+		PermittedDNSDomains: m.dnsWhitelist,
 	}
 
 	cert, err := x509.CreateCertificate(rand.Reader, tpl, tpl, pub, priv)


### PR DESCRIPTION
The -permit option can be used when the CA is generated to only allow certain domains to have certificates issued by the local CA. This allows for a development CA to have the minimum possible responsibility, provided the dev cert stack checks the domain restrictions.

This uses the NameConstraints X509 extension, so it is not implemented by all OSes/browsers, which is reflected in the help message for the option.